### PR TITLE
chore: update code owner to reflect new team name

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # See https://help.github.com/articles/about-codeowners/ for more information about this file.
 
-* @Financial-Times/accounts
+* @financial-times/cp-retention-team


### PR DESCRIPTION
As part of the overarching team objective to update our identity, this PR modifies the 'codeowner' entry to align with our newly adopted team name

[Ticket](https://financialtimes.atlassian.net/browse/ACC-2709)